### PR TITLE
Investigate Records not Binding from Config

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build & Push Docker Image to ACR
 
 on:
   push:
-    branches: [ main ]
+    branches: [ dev ]
 
 env:
   ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}    # vanfmly.azurecr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build & push
         uses: docker/build-push-action@v5
         with:
-          context: ./_src
+          context: .
           file:    ./_src/CloudflareDdns.Server/Dockerfile
           push:    true
           tags: |

--- a/_src/CloudflareDdns.Server/CloudflareDdns.Server.csproj
+++ b/_src/CloudflareDdns.Server/CloudflareDdns.Server.csproj
@@ -6,6 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<UserSecretsId>7cf4c760-5c39-4e98-9684-d831d9e802ae</UserSecretsId>
+		<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/_src/CloudflareDdns.Server/CloudflareDdns.Server.csproj
+++ b/_src/CloudflareDdns.Server/CloudflareDdns.Server.csproj
@@ -11,7 +11,6 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
 		<PackageReference Include="Azure.Identity" Version="1.12.0" />
-		<PackageReference Include="Devv.CloudflareDdns" Version="*" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
@@ -20,9 +19,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Content Include="..\..\.dockerignore">
+		  <Link>.dockerignore</Link>
+		</Content>
 		<Content Include="..\.dockerignore">
 			<Link>.dockerignore</Link>
 		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Devv.CloudflareDdns\Devv.CloudflareDdns.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -1,32 +1,72 @@
-# 1) Restore + build
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-ARG BUILD_CONFIGURATION=Release
-WORKDIR /src
-COPY CloudflareDdns.Server/CloudflareDdns.Server.csproj ./CloudflareDdns.Server/
-RUN dotnet restore ./CloudflareDdns.Server/CloudflareDdns.Server.csproj
-COPY CloudflareDdns.Server/. ./CloudflareDdns.Server/
-WORKDIR /src/CloudflareDdns.Server
-RUN dotnet build -c $BUILD_CONFIGURATION -o /app/build
+# syntax=docker/dockerfile:1.4
 
-# 2) Publish trimmed, single-file
+###############################################################################
+# 1) Build + restore
+###############################################################################
+FROM mcr.microsoft.com/dotnet/sdk:8.0-slim AS build
+ARG BUILD_CONFIGURATION=Release
+
+WORKDIR /src
+
+# Copy only the csproj files first (for a faster restore)
+COPY _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+     _src/Devv.CloudflareDdns/Devv.CloudflareDdns.csproj ./
+
+RUN dotnet restore ./CloudflareDdns.Server.csproj
+
+# Copy the rest of your code
+COPY . .
+
+WORKDIR /src
+
+# Build out the binaries
+RUN dotnet build \
+      _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+      -c $BUILD_CONFIGURATION \
+      -o /app/build \
+      --no-restore
+
+###############################################################################
+# 2) Publish as a single, trimmed, self-contained file
+###############################################################################
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 
-RUN dotnet publish \
-    ./CloudflareDdns.Server.csproj \
-    -c $BUILD_CONFIGURATION \
-    -o /app/publish \
-    -r linux-x64 \
-    /p:SelfContained=true \
-    /p:PublishSingleFile=true \
-    /p:PublishTrimmed=true \
-    /p:PublishReadyToRun=true \
-    /p:UseAppHost=true
+WORKDIR /src
 
-# 3) Final: Debian 12 slim runtime-deps
+RUN dotnet publish \
+      _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+      -c $BUILD_CONFIGURATION \
+      -r linux-x64 \
+      --self-contained true \
+      /p:PublishSingleFile=true \
+      /p:PublishTrimmed=true \
+      /p:PublishReadyToRun=true \
+      -o /app/publish \
+      --no-build
+
+###############################################################################
+# 3) Final: minimal Debian “runtime-deps” with non-root user
+###############################################################################
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final
-USER app
+
+# Create and switch to a non-root user
+ARG APP_UID=1000
+ARG APP_GID=1000
+RUN groupadd --gid $APP_GID app \
+ && useradd --uid $APP_UID --gid $APP_GID \
+            --home-dir /app --no-log-init --create-home app
+
 WORKDIR /app
+
+# Copy over the single-file publish output
 COPY --from=publish /app/publish ./
+
+# Expose the same ports you’ve configured in ASP.NET Core
+ENV ASPNETCORE_URLS=http://+:8080;https://+:8081
+EXPOSE 8080 8081
+
+USER app
+
+# Launch the single-file Linux executable
 ENTRYPOINT ["./CloudflareDdns.Server"]
-EXPOSE 8080

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -49,14 +49,16 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final
 
 ARG APP_UID=1000
 
-# Create a non-root user (and a matching group) in one step
-RUN useradd \
-      --uid $APP_UID \
-      --home-dir /app \
-      --no-log-init \
-      --create-home \
-      --shell /sbin/nologin \
-      app
+# Create 'app' user only if it doesn't exist
+RUN if ! id app >/dev/null 2>&1; then \
+      useradd \
+        --uid $APP_UID \
+        --home-dir /app \
+        --no-log-init \
+        --create-home \
+        --shell /sbin/nologin \
+        app; \
+    fi
 
 WORKDIR /app
 USER app

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -8,20 +8,23 @@ ARG BUILD_CONFIGURATION=Release
 
 WORKDIR /src
 
-# Copy each csproj into its matching folder for restore
-COPY _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj _src/CloudflareDdns.Server/
-COPY _src/Devv.CloudflareDdns/Devv.CloudflareDdns.csproj _src/Devv.CloudflareDdns/
+# Copy project files
+COPY CloudflareDdns.Server/CloudflareDdns.Server.csproj CloudflareDdns.Server/
+COPY Devv.CloudflareDdns/Devv.CloudflareDdns.csproj Devv.CloudflareDdns/
 
-# Restore Server (which will pull in Devv.CloudflareDdns as a project reference)
-RUN dotnet restore _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj
+# Restore including the linux-x64 RID so project.assets.json has the right target
+RUN dotnet restore \
+      CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+      -r linux-x64
 
 # Copy the rest of your source
 COPY . .
 
-# Build into /app/build
+# Build for linux-x64 (no restore) into /app/build
 RUN dotnet build \
-      _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+      CloudflareDdns.Server/CloudflareDdns.Server.csproj \
       -c $BUILD_CONFIGURATION \
+      -r linux-x64 \
       -o /app/build \
       --no-restore
 
@@ -31,8 +34,9 @@ RUN dotnet build \
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 
+# Publish (no build) now that rid-specific assets exist
 RUN dotnet publish \
-      _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+      CloudflareDdns.Server/CloudflareDdns.Server.csproj \
       -c $BUILD_CONFIGURATION \
       -r linux-x64 \
       --self-contained true \
@@ -43,13 +47,12 @@ RUN dotnet publish \
       --no-build
 
 ###############################################################################
-# 3) Final: minimal Debian “Bookworm-slim” runtime-deps + non-root user
+# 3) Final: minimal Debian “Bookworm-slim” runtime-deps + safe non-root user
 ###############################################################################
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final
-
 ARG APP_UID=1000
 
-# Create 'app' user only if it doesn't exist
+# Only create the 'app' user if it doesn't already exist
 RUN if ! id app >/dev/null 2>&1; then \
       useradd \
         --uid $APP_UID \
@@ -63,10 +66,10 @@ RUN if ! id app >/dev/null 2>&1; then \
 WORKDIR /app
 USER app
 
-# Copy the published single-file output
+# Copy the single-file publish output
 COPY --from=publish /app/publish ./
 
-# Configure Kestrel ports
+# Tell Kestrel to listen on 8080 and 8081
 ENV ASPNETCORE_URLS="http://+:8080;https://+:8081"
 EXPOSE 8080 8081
 

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -3,23 +3,21 @@
 ###############################################################################
 # 1) Build + restore
 ###############################################################################
-FROM mcr.microsoft.com/dotnet/sdk:8.0-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build  
 ARG BUILD_CONFIGURATION=Release
 
 WORKDIR /src
 
-# Copy only the csproj files first (for a faster restore)
+# Copy only the csproj files first for Docker layer caching
 COPY _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
      _src/Devv.CloudflareDdns/Devv.CloudflareDdns.csproj ./
 
-RUN dotnet restore ./CloudflareDdns.Server.csproj
+RUN dotnet restore CloudflareDdns.Server.csproj
 
 # Copy the rest of your code
 COPY . .
 
-WORKDIR /src
-
-# Build out the binaries
+# Build binaries
 RUN dotnet build \
       _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
       -c $BUILD_CONFIGURATION \
@@ -46,27 +44,27 @@ RUN dotnet publish \
       --no-build
 
 ###############################################################################
-# 3) Final: minimal Debian “runtime-deps” with non-root user
+# 3) Final: minimal Debian “Bookworm-slim” runtime-deps
 ###############################################################################
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final 
 
-# Create and switch to a non-root user
 ARG APP_UID=1000
 ARG APP_GID=1000
+
+# Create a non-root app user
 RUN groupadd --gid $APP_GID app \
  && useradd --uid $APP_UID --gid $APP_GID \
             --home-dir /app --no-log-init --create-home app
 
 WORKDIR /app
+USER app
 
-# Copy over the single-file publish output
+# Copy the published single-file app
 COPY --from=publish /app/publish ./
 
-# Expose the same ports you’ve configured in ASP.NET Core
+# Tell Kestrel which ports to listen on
 ENV ASPNETCORE_URLS=http://+:8080;https://+:8081
 EXPOSE 8080 8081
 
-USER app
-
-# Launch the single-file Linux executable
+# Run it!
 ENTRYPOINT ["./CloudflareDdns.Server"]

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -12,8 +12,10 @@ WORKDIR /src
 COPY _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj _src/CloudflareDdns.Server/
 COPY _src/Devv.CloudflareDdns/Devv.CloudflareDdns.csproj _src/Devv.CloudflareDdns/
 
-# Restore Server (which will pull in Devv.CloudflareDdns as a project reference)
-RUN dotnet restore _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj
+# Restore Server (including linux-x64 RID so assets.json has net8.0/linux-x64)
+RUN dotnet restore \
+      _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+      -r linux-x64
 
 # Copy the rest of your source
 COPY . .

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -42,8 +42,7 @@ RUN dotnet publish \
       --self-contained true \
       /p:PublishSingleFile=true \
       /p:PublishTrimmed=true \      
-      -o /app/publish \
-      --no-build
+      -o /app/publish
 
 ###############################################################################
 # 3) Final: minimal Debian “Bookworm-slim” runtime-deps + non-root user

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -8,21 +8,19 @@ ARG BUILD_CONFIGURATION=Release
 
 WORKDIR /src
 
-# Copy project files
-COPY CloudflareDdns.Server/CloudflareDdns.Server.csproj CloudflareDdns.Server/
-COPY Devv.CloudflareDdns/Devv.CloudflareDdns.csproj Devv.CloudflareDdns/
+# Copy each csproj into its matching folder for restore
+COPY _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj _src/CloudflareDdns.Server/
+COPY _src/Devv.CloudflareDdns/Devv.CloudflareDdns.csproj _src/Devv.CloudflareDdns/
 
-# Restore including the linux-x64 RID so project.assets.json has the right target
-RUN dotnet restore \
-      CloudflareDdns.Server/CloudflareDdns.Server.csproj \
-      -r linux-x64
+# Restore Server (which will pull in Devv.CloudflareDdns as a project reference)
+RUN dotnet restore _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj
 
 # Copy the rest of your source
 COPY . .
 
-# Build for linux-x64 (no restore) into /app/build
+# Build into /app/build
 RUN dotnet build \
-      CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+      _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
       -c $BUILD_CONFIGURATION \
       -r linux-x64 \
       -o /app/build \
@@ -34,9 +32,8 @@ RUN dotnet build \
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 
-# Publish (no build) now that rid-specific assets exist
 RUN dotnet publish \
-      CloudflareDdns.Server/CloudflareDdns.Server.csproj \
+      _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
       -c $BUILD_CONFIGURATION \
       -r linux-x64 \
       --self-contained true \
@@ -47,12 +44,13 @@ RUN dotnet publish \
       --no-build
 
 ###############################################################################
-# 3) Final: minimal Debian “Bookworm-slim” runtime-deps + safe non-root user
+# 3) Final: minimal Debian “Bookworm-slim” runtime-deps + non-root user
 ###############################################################################
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final
+
 ARG APP_UID=1000
 
-# Only create the 'app' user if it doesn't already exist
+# Create 'app' user only if it doesn't exist
 RUN if ! id app >/dev/null 2>&1; then \
       useradd \
         --uid $APP_UID \
@@ -66,10 +64,10 @@ RUN if ! id app >/dev/null 2>&1; then \
 WORKDIR /app
 USER app
 
-# Copy the single-file publish output
+# Copy the published single-file output
 COPY --from=publish /app/publish ./
 
-# Tell Kestrel to listen on 8080 and 8081
+# Configure Kestrel ports
 ENV ASPNETCORE_URLS="http://+:8080;https://+:8081"
 EXPOSE 8080 8081
 

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -48,23 +48,24 @@ RUN dotnet publish \
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final
 
 ARG APP_UID=1000
-ARG APP_GID=1000
 
-# Create group only if it doesn't exist, then user
-RUN if ! getent group app >/dev/null; then \
-      groupadd --gid $APP_GID app; \
-    fi && \
-    useradd --uid $APP_UID --gid $APP_GID \
-            --home-dir /app --no-log-init --create-home app
+# Create a non-root user (and a matching group) in one step
+RUN useradd \
+      --uid $APP_UID \
+      --home-dir /app \
+      --no-log-init \
+      --create-home \
+      --shell /sbin/nologin \
+      app
 
 WORKDIR /app
 USER app
 
-# Copy publish output
+# Copy the published single-file output
 COPY --from=publish /app/publish ./
 
 # Configure Kestrel ports
-ENV ASPNETCORE_URLS=http://+:8080;https://+:8081
+ENV ASPNETCORE_URLS="http://+:8080;https://+:8081"
 EXPOSE 8080 8081
 
 ENTRYPOINT ["./CloudflareDdns.Server"]

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -69,7 +69,7 @@ USER app
 COPY --from=publish /app/publish ./
 
 # Configure Kestrel ports
-ENV ASPNETCORE_URLS="http://+:8080;https://+:8081"
-EXPOSE 8080 8081
+ENV ASPNETCORE_URLS="http://+:8080;"
+EXPOSE 8080
 
 ENTRYPOINT ["./CloudflareDdns.Server"]

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -50,20 +50,21 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final
 ARG APP_UID=1000
 ARG APP_GID=1000
 
-# create non-root user
-RUN groupadd --gid $APP_GID app \
- && useradd --uid $APP_UID --gid $APP_GID \
+# Create group only if it doesn't exist, then user
+RUN if ! getent group app >/dev/null; then \
+      groupadd --gid $APP_GID app; \
+    fi && \
+    useradd --uid $APP_UID --gid $APP_GID \
             --home-dir /app --no-log-init --create-home app
 
 WORKDIR /app
 USER app
 
-# copy the published single-file output
+# Copy publish output
 COPY --from=publish /app/publish ./
 
-# tell Kestrel which ports to bind
+# Configure Kestrel ports
 ENV ASPNETCORE_URLS=http://+:8080;https://+:8081
 EXPOSE 8080 8081
 
-# run
 ENTRYPOINT ["./CloudflareDdns.Server"]

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -1,23 +1,24 @@
 # syntax=docker/dockerfile:1.4
 
 ###############################################################################
-# 1) Build + restore
+# 1) Restore + build
 ###############################################################################
-FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build  
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 ARG BUILD_CONFIGURATION=Release
 
 WORKDIR /src
 
-# Copy only the csproj files first for Docker layer caching
-COPY _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
-     _src/Devv.CloudflareDdns/Devv.CloudflareDdns.csproj ./
+# Copy each csproj into its matching folder for restore
+COPY _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj _src/CloudflareDdns.Server/
+COPY _src/Devv.CloudflareDdns/Devv.CloudflareDdns.csproj _src/Devv.CloudflareDdns/
 
-RUN dotnet restore CloudflareDdns.Server.csproj
+# Restore Server (which will pull in Devv.CloudflareDdns as a project reference)
+RUN dotnet restore _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj
 
-# Copy the rest of your code
+# Copy the rest of your source
 COPY . .
 
-# Build binaries
+# Build into /app/build
 RUN dotnet build \
       _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
       -c $BUILD_CONFIGURATION \
@@ -29,8 +30,6 @@ RUN dotnet build \
 ###############################################################################
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-
-WORKDIR /src
 
 RUN dotnet publish \
       _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
@@ -44,14 +43,14 @@ RUN dotnet publish \
       --no-build
 
 ###############################################################################
-# 3) Final: minimal Debian “Bookworm-slim” runtime-deps
+# 3) Final: minimal Debian “Bookworm-slim” runtime-deps + non-root user
 ###############################################################################
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final 
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim AS final
 
 ARG APP_UID=1000
 ARG APP_GID=1000
 
-# Create a non-root app user
+# create non-root user
 RUN groupadd --gid $APP_GID app \
  && useradd --uid $APP_UID --gid $APP_GID \
             --home-dir /app --no-log-init --create-home app
@@ -59,12 +58,12 @@ RUN groupadd --gid $APP_GID app \
 WORKDIR /app
 USER app
 
-# Copy the published single-file app
+# copy the published single-file output
 COPY --from=publish /app/publish ./
 
-# Tell Kestrel which ports to listen on
+# tell Kestrel which ports to bind
 ENV ASPNETCORE_URLS=http://+:8080;https://+:8081
 EXPOSE 8080 8081
 
-# Run it!
+# run
 ENTRYPOINT ["./CloudflareDdns.Server"]

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -15,7 +15,8 @@ COPY _src/Devv.CloudflareDdns/Devv.CloudflareDdns.csproj _src/Devv.CloudflareDdn
 # Restore Server (including linux-x64 RID so assets.json has net8.0/linux-x64)
 RUN dotnet restore \
       _src/CloudflareDdns.Server/CloudflareDdns.Server.csproj \
-      -r linux-x64
+      -r linux-x64 \
+      /p:PublishReadyToRun=true
 
 # Copy the rest of your source
 COPY . .

--- a/_src/CloudflareDdns.Server/Dockerfile
+++ b/_src/CloudflareDdns.Server/Dockerfile
@@ -41,8 +41,7 @@ RUN dotnet publish \
       -r linux-x64 \
       --self-contained true \
       /p:PublishSingleFile=true \
-      /p:PublishTrimmed=true \
-      /p:PublishReadyToRun=true \
+      /p:PublishTrimmed=true \      
       -o /app/publish \
       --no-build
 

--- a/_src/CloudflareDdns.Server/Program.cs
+++ b/_src/CloudflareDdns.Server/Program.cs
@@ -46,6 +46,16 @@ public class Program
                 Log.Information("{key} = {value}", keyValuePair.Key, keyValuePair.Value);
             }
             
+            var section = config.GetSection(CloudFlareOptions.SectionName);
+            var opts    = section.Get<CloudFlareOptions>();
+            
+            Console.WriteLine($"Records array is {(opts.Records == null ? "null" : opts.Records.Length.ToString())}");
+            if (opts.Records is not null)
+            {
+                for (var i = 0; i < opts.Records.Length; i++)
+                    Console.WriteLine($" • [{i}] {opts.Records[i].Name} ({opts.Records[i].ZoneId})");
+            }
+            
             builder.Services.AddCloudflareDynamicDns(config);
 
             var app = builder.Build();

--- a/_src/CloudflareDdns.Server/Program.cs
+++ b/_src/CloudflareDdns.Server/Program.cs
@@ -27,12 +27,9 @@ public class Program
                         listenOptions.UseHttps());
                 }
             });
-
-            var config = builder.Configuration;
-
-            config.AddEnvironmentVariables();
             
-
+            builder.Configuration.AddEnvironmentVariables();
+            
             builder.Services.AddSerilog((services, lc) =>
                 lc.Filter.ByExcluding(Matching.WithProperty<string>("RequestPath", path =>
                         path != null && path.Contains("/_health")))
@@ -41,22 +38,7 @@ public class Program
 
             builder.Services.AddHealthChecks();
             
-            foreach (var keyValuePair in config.AsEnumerable())
-            {
-                Log.Information("{key} = {value}", keyValuePair.Key, keyValuePair.Value);
-            }
-            
-            var section = config.GetSection(CloudFlareOptions.SectionName);
-            var opts    = section.Get<CloudFlareOptions>();
-            
-            Console.WriteLine($"Records array is {(opts.Records == null ? "null" : opts.Records.Length.ToString())}");
-            if (opts.Records is not null)
-            {
-                for (var i = 0; i < opts.Records.Length; i++)
-                    Console.WriteLine($" • [{i}] {opts.Records[i].Name} ({opts.Records[i].ZoneId})");
-            }
-            
-            builder.Services.AddCloudflareDynamicDns(config);
+            builder.Services.AddCloudflareDynamicDns(builder.Configuration);
 
             var app = builder.Build();
 

--- a/_src/CloudflareDdns.Server/Program.cs
+++ b/_src/CloudflareDdns.Server/Program.cs
@@ -31,7 +31,7 @@ public class Program
             var config = builder.Configuration;
 
             config.AddEnvironmentVariables();
-            builder.Services.AddCloudflareDynamicDns(config);
+            
 
             builder.Services.AddSerilog((services, lc) =>
                 lc.Filter.ByExcluding(Matching.WithProperty<string>("RequestPath", path =>
@@ -40,12 +40,13 @@ public class Program
                     .WriteTo.Console());
 
             builder.Services.AddHealthChecks();
-
-
+            
             foreach (var keyValuePair in config.AsEnumerable())
             {
                 Log.Information("{key} = {value}", keyValuePair.Key, keyValuePair.Value);
             }
+            
+            builder.Services.AddCloudflareDynamicDns(config);
 
             var app = builder.Build();
 

--- a/_src/CloudflareDdns.Server/Program.cs
+++ b/_src/CloudflareDdns.Server/Program.cs
@@ -16,8 +16,20 @@ public class Program
         try
         {
             var builder = WebApplication.CreateBuilder(args);
+
+            builder.WebHost.ConfigureKestrel(options =>
+            {
+                options.ListenAnyIP(8080);
+
+                if (builder.Environment.IsDevelopment())
+                {
+                    options.ListenAnyIP(8081, listenOptions =>
+                        listenOptions.UseHttps());
+                }
+            });
+
             var config = builder.Configuration;
-            
+
             config.AddEnvironmentVariables();
             builder.Services.AddCloudflareDynamicDns(config);
 
@@ -28,8 +40,8 @@ public class Program
                     .WriteTo.Console());
 
             builder.Services.AddHealthChecks();
-            
-            
+
+
             foreach (var keyValuePair in config.AsEnumerable())
             {
                 Log.Information("{key} = {value}", keyValuePair.Key, keyValuePair.Value);

--- a/_src/CloudflareDdns.Server/Program.cs
+++ b/_src/CloudflareDdns.Server/Program.cs
@@ -41,13 +41,6 @@ public class Program
             var section = builder.Configuration.GetSection(CloudFlareOptions.SectionName);
             var opts    = section.Get<CloudFlareOptions>();
             
-            Console.WriteLine($"Records array is {(opts.Records == null ? "null" : opts.Records.Length.ToString())}");
-            if (opts.Records is not null)
-            {
-                for (var i = 0; i < opts.Records.Length; i++)
-                    Console.WriteLine($" • [{i}] {opts.Records[i].Name} ({opts.Records[i].ZoneId})");
-            }
-            
             builder.Services.AddCloudflareDynamicDns(builder.Configuration);
 
             var app = builder.Build();

--- a/_src/CloudflareDdns.Server/Program.cs
+++ b/_src/CloudflareDdns.Server/Program.cs
@@ -38,6 +38,16 @@ public class Program
 
             builder.Services.AddHealthChecks();
             
+            var section = builder.Configuration.GetSection(CloudFlareOptions.SectionName);
+            var opts    = section.Get<CloudFlareOptions>();
+            
+            Console.WriteLine($"Records array is {(opts.Records == null ? "null" : opts.Records.Length.ToString())}");
+            if (opts.Records is not null)
+            {
+                for (var i = 0; i < opts.Records.Length; i++)
+                    Console.WriteLine($" • [{i}] {opts.Records[i].Name} ({opts.Records[i].ZoneId})");
+            }
+            
             builder.Services.AddCloudflareDynamicDns(builder.Configuration);
 
             var app = builder.Build();

--- a/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
@@ -19,35 +19,6 @@ public class CloudFlareHttpClient : ICloudFlareService, IPublicIpProvider
         _options = options.Value;
     }
 
-    public async Task RunAsync(string publicIp)
-    {
-        
-        Console.WriteLine("=== CloudFlareOptions ===");
-        Console.WriteLine($"Email = {_options.Email}");
-        Console.WriteLine($"Key   = {_options.Key}");
-        Console.WriteLine($"ApiUrl = {_options.ApiUrl}");
-        Console.WriteLine($"Records = {(_options.Records == null ? "null" : _options.Records.Length.ToString())}");
-        if (_options.Records != null)
-        {
-            foreach (var r in _options.Records)
-                Console.WriteLine($"  • {r.Name}: {r.ZoneId} / {r.DnsRecordId}");
-        }
-
-        foreach (var record in _options.Records)
-        {
-            try
-            {
-                _logger.LogInformation("Updating DNS record {recordName}", record.Name);
-                await SendPublicIpToCloudFlareAsync(publicIp, record.ZoneId, record.DnsRecordId, record.Name);
-                _logger.LogInformation("DNS record {recordName} updated", record.Name);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "An error occurred while updating the DNS record");
-            }
-        }
-    }
-
     private async Task SendPublicIpToCloudFlareAsync(string publicIp,
         string zoneId,
         string dnsRecordId,
@@ -81,6 +52,17 @@ public class CloudFlareHttpClient : ICloudFlareService, IPublicIpProvider
 
     public async Task UpdateDnsRecordsAsync(string publicIp, CancellationToken cancellationToken)
     {
+        _logger.LogWarning("=== CloudFlareOptions ===");
+        _logger.LogWarning($"Email = {_options.Email}");
+        _logger.LogWarning($"Key   = {_options.Key}");
+        _logger.LogWarning($"ApiUrl = {_options.ApiUrl}");
+        _logger.LogWarning($"Records = {(_options.Records == null ? "null" : _options.Records.Length.ToString())}");
+        if (_options.Records != null)
+        {
+            foreach (var r in _options.Records)
+                _logger.LogWarning($"  • {r.Name}: {r.ZoneId} / {r.DnsRecordId}");
+        }
+        
         if (_options.Records == null || !_options.Records.Any())
         {
             _logger.LogWarning("No DNS records found to update");

--- a/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
@@ -56,7 +56,7 @@ public class CloudFlareHttpClient : ICloudFlareService, IPublicIpProvider
         _logger.LogWarning($"Email = {_options.Email}");
         _logger.LogWarning($"Key   = {_options.Key}");
         _logger.LogWarning($"ApiUrl = {_options.ApiUrl}");
-        _logger.LogWarning($"Records = {(_options.Records == null ? "null" : _options.Records.Count.ToString())}");
+        _logger.LogWarning($"Records = {(_options.Records == null ? "null" : _options.Records.Length.ToString())}");
         if (_options.Records != null)
         {
             foreach (var r in _options.Records)

--- a/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
@@ -29,7 +29,7 @@ public class CloudFlareHttpClient : ICloudFlareService, IPublicIpProvider
         dnsRecordId,
         recordName,
         publicIp,
-        $"Dynamic DNS Update {DateTime.UtcNow:o}"
+        $"Dynamic DNS Update {DateTime.UtcNow:g}"
         );
 
         // Using PutAsJsonAsync with your source-generated context:

--- a/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
@@ -56,7 +56,7 @@ public class CloudFlareHttpClient : ICloudFlareService, IPublicIpProvider
         _logger.LogWarning($"Email = {_options.Email}");
         _logger.LogWarning($"Key   = {_options.Key}");
         _logger.LogWarning($"ApiUrl = {_options.ApiUrl}");
-        _logger.LogWarning($"Records = {(_options.Records == null ? "null" : _options.Records.Length.ToString())}");
+        _logger.LogWarning($"Records = {(_options.Records == null ? "null" : _options.Records.Count.ToString())}");
         if (_options.Records != null)
         {
             foreach (var r in _options.Records)

--- a/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
@@ -24,7 +24,7 @@ public class CloudFlareHttpClient : ICloudFlareService, IPublicIpProvider
         string dnsRecordId,
         string recordName)
     {
-        var body = new DnsRecord(dnsRecordId, recordName, publicIp, "Dynamic DNS Update");
+        var body = new DnsRecord(dnsRecordId, recordName, publicIp, $"Dynamic DNS Update {DateTime.UtcNow}", "A");
         var request = new HttpRequestMessage(HttpMethod.Put,
         $"/client/v4/zones/{zoneId}/dns_records/{dnsRecordId}");
         request.Content = JsonContent.Create(body);

--- a/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
@@ -52,17 +52,6 @@ public class CloudFlareHttpClient : ICloudFlareService, IPublicIpProvider
 
     public async Task UpdateDnsRecordsAsync(string publicIp, CancellationToken cancellationToken)
     {
-        _logger.LogWarning("=== CloudFlareOptions ===");
-        _logger.LogWarning($"Email = {_options.Email}");
-        _logger.LogWarning($"Key   = {_options.Key}");
-        _logger.LogWarning($"ApiUrl = {_options.ApiUrl}");
-        _logger.LogWarning($"Records = {(_options.Records == null ? "null" : _options.Records.Length.ToString())}");
-        if (_options.Records != null)
-        {
-            foreach (var r in _options.Records)
-                _logger.LogWarning($"  • {r.Name}: {r.ZoneId} / {r.DnsRecordId}");
-        }
-        
         if (_options.Records == null || !_options.Records.Any())
         {
             _logger.LogWarning("No DNS records found to update");

--- a/_src/Devv.CloudflareDdns/CloudFlareOptions.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareOptions.cs
@@ -6,10 +6,10 @@ public class CloudFlareOptions
     public Uri? ApiUrl { get; set; } = new Uri("https://api.cloudflare.com");
     public string? Email { get; set; }
     public string? Key { get; set; }
-    public Records[]? Records { get; set; }
+    public Record[]? Records { get; set; }
 }
 
-public class Records
+public class Record
 {
     public string? ZoneId { get; set; }
     public string? DnsRecordId { get; set; }

--- a/_src/Devv.CloudflareDdns/CloudFlareOptions.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareOptions.cs
@@ -6,7 +6,7 @@ public class CloudFlareOptions
     public Uri? ApiUrl { get; set; } = new Uri("https://api.cloudflare.com");
     public string? Email { get; set; }
     public string? Key { get; set; }
-    public Records[]? Records { get; set; }
+    public List<Records>? Records { get; set; }
 }
 
 public class Records

--- a/_src/Devv.CloudflareDdns/CloudFlareOptions.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareOptions.cs
@@ -6,7 +6,7 @@ public class CloudFlareOptions
     public Uri? ApiUrl { get; set; } = new Uri("https://api.cloudflare.com");
     public string? Email { get; set; }
     public string? Key { get; set; }
-    public List<Records>? Records { get; set; }
+    public Records[]? Records { get; set; }
 }
 
 public class Records

--- a/_src/Devv.CloudflareDdns/ConfigureServices.cs
+++ b/_src/Devv.CloudflareDdns/ConfigureServices.cs
@@ -11,8 +11,8 @@ namespace Devv.CloudflareDdns
     {
         public static IServiceCollection AddCloudflareDynamicDns(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddOptions<CloudFlareOptions>()
-                .BindConfiguration(CloudFlareOptions.SectionName);
+            services.Configure<CloudFlareOptions>
+                (configuration.GetSection(CloudFlareOptions.SectionName));
 
             services.AddHttpClient<ICloudFlareService, CloudFlareHttpClient>((sp, client) =>
             {

--- a/_src/Devv.CloudflareDdns/ConfigureServices.cs
+++ b/_src/Devv.CloudflareDdns/ConfigureServices.cs
@@ -11,8 +11,8 @@ namespace Devv.CloudflareDdns
     {
         public static IServiceCollection AddCloudflareDynamicDns(this IServiceCollection services, IConfiguration configuration)
         {
-            services.Configure<CloudFlareOptions>
-                (configuration.GetSection(CloudFlareOptions.SectionName));
+            services.AddOptions<CloudFlareOptions>()
+                .Bind (configuration.GetSection(CloudFlareOptions.SectionName));
 
             services.AddHttpClient<ICloudFlareService, CloudFlareHttpClient>((sp, client) =>
             {

--- a/_src/Devv.CloudflareDdns/ConfigureServices.cs
+++ b/_src/Devv.CloudflareDdns/ConfigureServices.cs
@@ -11,16 +11,6 @@ namespace Devv.CloudflareDdns
     {
         public static IServiceCollection AddCloudflareDynamicDns(this IServiceCollection services, IConfiguration configuration)
         {
-            var section = configuration.GetSection(CloudFlareOptions.SectionName);
-            var opts    = section.Get<CloudFlareOptions>();
-            
-            Console.WriteLine($"Records array is {(opts.Records == null ? "null" : opts.Records.Length.ToString())}");
-            if (opts.Records is not null)
-            {
-                for (var i = 0; i < opts.Records.Length; i++)
-                    Console.WriteLine($" • [{i}] {opts.Records[i].Name} ({opts.Records[i].ZoneId})");
-            }
-            
             services.Configure<CloudFlareOptions>
                 (configuration.GetSection(CloudFlareOptions.SectionName));
 

--- a/_src/Devv.CloudflareDdns/ConfigureServices.cs
+++ b/_src/Devv.CloudflareDdns/ConfigureServices.cs
@@ -11,6 +11,16 @@ namespace Devv.CloudflareDdns
     {
         public static IServiceCollection AddCloudflareDynamicDns(this IServiceCollection services, IConfiguration configuration)
         {
+            var section = configuration.GetSection(CloudFlareOptions.SectionName);
+            var opts    = section.Get<CloudFlareOptions>();
+            
+            Console.WriteLine($"Records array is {(opts.Records == null ? "null" : opts.Records.Length.ToString())}");
+            if (opts.Records is not null)
+            {
+                for (var i = 0; i < opts.Records.Length; i++)
+                    Console.WriteLine($" • [{i}] {opts.Records[i].Name} ({opts.Records[i].ZoneId})");
+            }
+            
             services.Configure<CloudFlareOptions>
                 (configuration.GetSection(CloudFlareOptions.SectionName));
 

--- a/_src/Devv.CloudflareDdns/DnsRecord.cs
+++ b/_src/Devv.CloudflareDdns/DnsRecord.cs
@@ -1,9 +1,12 @@
 ﻿namespace Devv.CloudflareDdns;
 
+using System.Text.Json.Serialization;
+
 public class DnsRecord
 {
     public DnsRecord() {}
 
+    [JsonConstructor]
     public DnsRecord(string id, string domain, string publicIp, string comment, string type = "A")
     {
         Id = id;
@@ -11,7 +14,6 @@ public class DnsRecord
         Name = domain;
         Content = publicIp;
         Type = type;
-        // Tags = new List<string> { "dynamic-dns" };
     }
 
     public string Id { get; set; } = default!;
@@ -30,3 +32,6 @@ public class DnsRecord
 
     public List<string> Tags { get; set; } = new();
 }
+
+[JsonSerializable(typeof(DnsRecord))]
+internal partial class CustomJsonContext : JsonSerializerContext { }

--- a/_src/Devv.CloudflareDdns/DnsRecord.cs
+++ b/_src/Devv.CloudflareDdns/DnsRecord.cs
@@ -2,6 +2,8 @@
 
 public class DnsRecord
 {
+    public DnsRecord() {}
+
     public DnsRecord(string id, string domain, string publicIp, string comment, string type = "A")
     {
         Id = id;
@@ -12,12 +14,19 @@ public class DnsRecord
         // Tags = new List<string> { "dynamic-dns" };
     }
 
-    public string Content { get; set; }
-    public string Name { get; set; }
+    public string Id { get; set; } = default!;
+
+    public string Name { get; set; } = default!;
+
+    public string Content { get; set; } = default!;
+
+    public string Comment { get; set; } = default!;
+
+    public string Type { get; set; } = "A";
+
     public bool Proxied { get; set; } = true;
-    public string Type { get; set; }
-    public string Comment { get; set; }
-    public string Id { get; set; }
-    public List<string> Tags { get; set; } = new List<string>();
+
     public int Ttl { get; set; } = 1;
+
+    public List<string> Tags { get; set; } = new();
 }

--- a/_src/Devv.CloudflareDdns/DynamicDnsWorker.cs
+++ b/_src/Devv.CloudflareDdns/DynamicDnsWorker.cs
@@ -1,20 +1,20 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Devv.CloudflareDdns;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-
-namespace Devv.CloudflareDdns;
 
 public class DynamicDnsWorker : BackgroundService
 {
     private readonly ILogger<DynamicDnsWorker> _logger;
-    private readonly IServiceProvider _serviceProvider;
-
+    private readonly IServiceScopeFactory _scopeFactory;
     private string _publicIp = string.Empty;
-    public DynamicDnsWorker(ILogger<DynamicDnsWorker> logger,
-        IServiceProvider serviceProvider)
+
+    public DynamicDnsWorker(
+        ILogger<DynamicDnsWorker> logger,
+        IServiceScopeFactory scopeFactory)
     {
-        _serviceProvider = serviceProvider;
         _logger = logger;
+        _scopeFactory = scopeFactory;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -23,30 +23,29 @@ public class DynamicDnsWorker : BackgroundService
         {
             try
             {
-                using (var scope = _serviceProvider.CreateScope())
+                using var scope = _scopeFactory.CreateScope();
+                var ipProvider = scope.ServiceProvider.GetRequiredService<IPublicIpProvider>();
+                var cloudFlareService = scope.ServiceProvider.GetRequiredService<ICloudFlareService>();
+
+                var publicIp = await ipProvider.GetPublicIpAsync(stoppingToken);
+                if (_publicIp != publicIp)
                 {
-                    var _ipProvider = scope.ServiceProvider.GetRequiredService<IPublicIpProvider>();
-                    var _cloudFlareService = scope.ServiceProvider.GetRequiredService<ICloudFlareService>();
-                    var publicIp = await _ipProvider.GetPublicIpAsync(stoppingToken);
-
-                    if (_publicIp != publicIp)
-                    {
-                        _logger.LogInformation("Public IP has changed. Updating DNS record");
-                        _publicIp = publicIp;
-                        await _cloudFlareService.UpdateDnsRecordsAsync(_publicIp, stoppingToken);
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Public IP has not changed");
-                    }
-
-                    await Task.Delay(TimeSpan.FromSeconds(60), stoppingToken);
+                    _logger.LogInformation("Public IP has changed. Updating DNS record");
+                    _publicIp = publicIp;
+                    await cloudFlareService.UpdateDnsRecordsAsync(publicIp, stoppingToken);
+                }
+                else
+                {
+                    _logger.LogInformation("Public IP has not changed");
                 }
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "An error occurred while updating the DNS record");
             }
+
+            // delay *outside* the scope so the scope is disposed immediately
+            await Task.Delay(TimeSpan.FromSeconds(60), stoppingToken);
         }
     }
 }

--- a/_test/UnitTests/CloudFlareHttpClientTests.cs
+++ b/_test/UnitTests/CloudFlareHttpClientTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 using Xunit;
+using Record=Devv.CloudflareDdns.Record;
 
 public class CloudFlareHttpClientTests
 {
@@ -31,7 +32,7 @@ public class CloudFlareHttpClientTests
 
         var httpClient = new HttpClient(handlerMock.Object);
         var logger = Mock.Of<ILogger<CloudFlareHttpClient>>();
-        var options = Options.Create(new CloudFlareOptions { Records = new Records[0] });
+        var options = Options.Create(new CloudFlareOptions { Records = new Record[0] });
 
         var client = new CloudFlareHttpClient(logger, httpClient, options);
 
@@ -46,7 +47,7 @@ public class CloudFlareHttpClientTests
     public async Task UpdateDnsRecordsAsync_LogsAndCallsApi()
     {
         // Arrange
-        var record = new Records { ZoneId = "zone", DnsRecordId = "dns", Name = "test.com" };
+        var record = new Record { ZoneId = "zone", DnsRecordId = "dns", Name = "test.com" };
         var options = Options.Create(new CloudFlareOptions { Records = new[] { record } });
         var logger = Mock.Of<ILogger<CloudFlareHttpClient>>();
 


### PR DESCRIPTION
This pull request introduces significant updates to improve the functionality, maintainability, and efficiency of the Cloudflare Dynamic DNS application. The changes include updates to the Docker build process, enhancements to the application configuration and dependency injection, refactoring of the `CloudFlareHttpClient` class, and improvements to unit tests. Below is a summary of the most important changes grouped by theme.

### Docker and Build Process Improvements
* Updated the GitHub Actions workflow to trigger Docker builds on the `dev` branch instead of `main` and changed the Docker build context from `./_src` to `.` for consistency. (`.github/workflows/docker-publish.yml`, [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L5-R5) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L33-R33)
* Enhanced the `Dockerfile` to use a slimmer .NET SDK image (`8.0-bookworm-slim`), added multi-stage builds with better organization, and improved runtime configuration by introducing a non-root user and setting Kestrel ports. (`_src/CloudflareDdns.Server/Dockerfile`, [_src/CloudflareDdns.Server/DockerfileR1-R75](diffhunk://#diff-922c9da971508200bf9f7b6e7ce3e220613c682d0cc6ae39b11994c49405d0bfR1-R75))

### Application Configuration and Dependency Injection
* Enabled reflection-based JSON serialization by default in the project file and replaced a package reference with a project reference for `Devv.CloudflareDdns`. (`_src/CloudflareDdns.Server/CloudflareDdns.Server.csproj`, [[1]](diffhunk://#diff-0a40ff6cccfa0bdb597c7e8fe813304a57c85b45888d0181e42a68322847012eR9-L14) [[2]](diffhunk://#diff-0a40ff6cccfa0bdb597c7e8fe813304a57c85b45888d0181e42a68322847012eR23-R34)
* Refactored the `DynamicDnsWorker` class to use `IServiceScopeFactory` instead of `IServiceProvider` for better scope management. (`_src/Devv.CloudflareDdns/DynamicDnsWorker.cs`, [[1]](diffhunk://#diff-9cb05875a5dbb39a89e85c6b194d9b9a69f1d410b65cc63768c7d55c8e06260bL1-R17)R1, [[2]](diffhunk://#diff-9cb05875a5dbb39a89e85c6b194d9b9a69f1d410b65cc63768c7d55c8e06260bL26-R48)

### Refactoring and Code Simplification
* Refactored `CloudFlareHttpClient` to streamline the DNS record update logic, improve error handling, and use source-generated JSON serialization with `CustomJsonContext`. (`_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs`, [[1]](diffhunk://#diff-9c9aa9256fb9b1d29df1b41adfe95146969408d6f85266f416f701cd95635ceeL13-R58) [[2]](diffhunk://#diff-9c9aa9256fb9b1d29df1b41adfe95146969408d6f85266f416f701cd95635ceeL81-R87)
* Renamed `Records` to `Record` in `CloudFlareOptions` and updated all references for clarity and consistency. (`_src/Devv.CloudflareDdns/CloudFlareOptions.cs`, [_src/Devv.CloudflareDdns/CloudFlareOptions.csL9-R12](diffhunk://#diff-d4537f502811fddc6c7e518387efee87716b327b4fe2577374c31d2324e6a775L9-R12))

### Unit Testing Enhancements
* Updated unit tests to reflect the renaming of `Records` to `Record` and ensure compatibility with the refactored `CloudFlareHttpClient`. (`_test/UnitTests/CloudFlareHttpClientTests.cs`, [[1]](diffhunk://#diff-8d69f8cff4d8283a620dc4433acec906634d13179efbf56321106d73913b58caR11) [[2]](diffhunk://#diff-8d69f8cff4d8283a620dc4433acec906634d13179efbf56321106d73913b58caL34-R35) [[3]](diffhunk://#diff-8d69f8cff4d8283a620dc4433acec906634d13179efbf56321106d73913b58caL49-R50)

### Additional Enhancements
* Introduced a `JsonConstructor` for the `DnsRecord` class and added source-generated JSON serialization support to improve performance and maintainability. (`_src/Devv.CloudflareDdns/DnsRecord.cs`, [_src/Devv.CloudflareDdns/DnsRecord.csR3-R37](diffhunk://#diff-08c0167e71b6fe7b195b5aebadd423e148d3b0f211ce8c2bc5b98a624a9a10e8R3-R37))
* Configured Kestrel to listen on specific ports and added HTTPS support for development environments. (`_src/CloudflareDdns.Server/Program.cs`, [[1]](diffhunk://#diff-f9ada97541fe2c3122e5c37e5f75db44eb4ae8f06a5b65c48e09d64b9fdf8fbcL19-R31) [[2]](diffhunk://#diff-f9ada97541fe2c3122e5c37e5f75db44eb4ae8f06a5b65c48e09d64b9fdf8fbcR41-R44)