### PR TITLE
Validate DNS record fields and improve tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: .NET Release & NuGet Publish
 on:
   push:
     branches:
-      - main   # or whichever branches you prefer
+      - main
 
 env:
   BUILD_CONFIGURATION: Release
@@ -14,40 +14,38 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. Checkout your code
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # 2. Install the .NET SDK
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          package-type: sdk
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            6.0.x
+            8.0.x
 
-      # 3. Restore NuGet packages
       - name: Restore dependencies
         run: dotnet restore ${{ env.PROJECT }}
 
-      # 4. Build the project
       - name: Build
         run: dotnet build ${{ env.PROJECT }} --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
-      # 5. Pack the project into a NuGet package
+      - name: Test
+        run: dotnet test --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal
+
       - name: Pack
-        # Here we use GitHub’s run number as a version suffix
         run: |
           dotnet pack ${{ env.PROJECT }} \
             --configuration ${{ env.BUILD_CONFIGURATION }} \
             --no-build \
-            /p:PackageVersion=1.0.${{ github.run_number }}
+            --output ./artifacts
 
-      # 6. Push to NuGet.org
       - name: Push package to NuGet.org
+        if: success()
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          dotnet nuget push "**/*.nupkg" \
+          dotnet nuget push "./artifacts/*.nupkg" \
             --api-key $NUGET_API_KEY \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 
 # Cloudflare Dynamic DNS Updater
 
+[![.NET Release & NuGet Publish](https://github.com/devv-guru/Devv.CloudflareDdns/actions/workflows/main.yml/badge.svg)](https://github.com/devv-guru/Devv.CloudflareDdns/actions/workflows/main.yml)
+[![NuGet](https://img.shields.io/nuget/v/Devv.CloudflareDdns.svg)](https://www.nuget.org/packages/Devv.CloudflareDdns/)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/Devv.CloudflareDdns.svg)](https://www.nuget.org/packages/Devv.CloudflareDdns/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A .NET 8 package to dynamically update Cloudflare DNS records based on changes to your public IP address. This package integrates with Cloudflare's API and automates the process of updating DNS records when the public IP changes.
 
 ## Features

--- a/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
+++ b/_src/Devv.CloudflareDdns/CloudFlareHttpClient.cs
@@ -73,6 +73,12 @@ public class CloudFlareHttpClient : ICloudFlareService
         {
             try
             {
+                if (string.IsNullOrEmpty(record.ZoneId) || string.IsNullOrEmpty(record.DnsRecordId) || string.IsNullOrEmpty(record.Name))
+                {
+                    _logger.LogWarning("Skipping invalid record: ZoneId, DnsRecordId, and Name are required");
+                    continue;
+                }
+
                 _logger.LogInformation("Updating DNS record {recordName}", record.Name);
                 await SendPublicIpToCloudFlareAsync(publicIp, record.ZoneId, record.DnsRecordId, record.Name,
                     record.Proxied, cancellationToken);

--- a/_src/Devv.CloudflareDdns/README.md
+++ b/_src/Devv.CloudflareDdns/README.md
@@ -1,6 +1,11 @@
 
 # Cloudflare Dynamic DNS Updater
 
+[![.NET Release & NuGet Publish](https://github.com/devv-guru/Devv.CloudflareDdns/actions/workflows/main.yml/badge.svg)](https://github.com/devv-guru/Devv.CloudflareDdns/actions/workflows/main.yml)
+[![NuGet](https://img.shields.io/nuget/v/Devv.CloudflareDdns.svg)](https://www.nuget.org/packages/Devv.CloudflareDdns/)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/Devv.CloudflareDdns.svg)](https://www.nuget.org/packages/Devv.CloudflareDdns/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A .NET 8 package to dynamically update Cloudflare DNS records based on changes to your public IP address. This package integrates with Cloudflare's API and automates the process of updating DNS records when the public IP changes.
 
 ## Features

--- a/_test/UnitTests/CloudFlareHttpClientTests.cs
+++ b/_test/UnitTests/CloudFlareHttpClientTests.cs
@@ -13,34 +13,85 @@ using Record=Devv.CloudflareDdns.Record;
 public class CloudFlareHttpClientTests
 {
     [Fact]
-    public async Task GetPublicIpAsync_ReturnsIp()
+    public async Task UpdateDnsRecordsAsync_WithProxiedTrue_CallsApi()
     {
         // Arrange
+        var record = new Record { ZoneId = "zone", DnsRecordId = "dns", Name = "test.com", Proxied = true };
+        var options = Options.Create(new CloudFlareOptions { Records = new[] { record } });
+        var logger = Mock.Of<ILogger<CloudFlareHttpClient>>();
+
         var handlerMock = new Mock<HttpMessageHandler>();
         handlerMock
             .Protected()
             .Setup<Task<HttpResponseMessage>>(
                 "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString().Contains("api.ipify.org")),
+                ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>()
             )
             .ReturnsAsync(new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("1.2.3.4"),
+                Content = new StringContent("{}"),
             });
 
-        var httpClient = new HttpClient(handlerMock.Object);
-        var logger = Mock.Of<ILogger<CloudFlareHttpClient>>();
-        var options = Options.Create(new CloudFlareOptions { Records = new Record[0] });
+        var httpClient = new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new System.Uri("https://api.cloudflare.com")
+        };
 
         var client = new CloudFlareHttpClient(logger, httpClient, options);
 
         // Act
-        var ip = await client.GetPublicIpAsync(CancellationToken.None);
+        await client.UpdateDnsRecordsAsync("1.2.3.4", CancellationToken.None);
 
-        // Assert
-        Assert.Equal("1.2.3.4", ip);
+        // Assert - verify the API was called
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>()
+        );
+    }
+
+    [Fact]
+    public async Task UpdateDnsRecordsAsync_WithProxiedFalse_CallsApi()
+    {
+        // Arrange
+        var record = new Record { ZoneId = "zone", DnsRecordId = "dns", Name = "test.com", Proxied = false };
+        var options = Options.Create(new CloudFlareOptions { Records = new[] { record } });
+        var logger = Mock.Of<ILogger<CloudFlareHttpClient>>();
+
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{}"),
+            });
+
+        var httpClient = new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new System.Uri("https://api.cloudflare.com")
+        };
+
+        var client = new CloudFlareHttpClient(logger, httpClient, options);
+
+        // Act
+        await client.UpdateDnsRecordsAsync("1.2.3.4", CancellationToken.None);
+
+        // Assert - verify the API was called
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>()
+        );
     }
 
     [Fact]

--- a/_test/UnitTests/DynamicDnsWorkerTests.cs
+++ b/_test/UnitTests/DynamicDnsWorkerTests.cs
@@ -1,9 +1,7 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Devv.CloudflareDdns;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 public class DynamicDnsWorkerTests
 {
@@ -19,7 +17,14 @@ public class DynamicDnsWorkerTests
             .ReturnsAsync("1.2.3.4")
             .ReturnsAsync("5.6.7.8");
 
-        var worker = new DynamicDnsWorker(ipProvider.Object, cloudFlareService.Object, logger);
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddScoped(_ => ipProvider.Object);
+        serviceCollection.AddScoped(_ => cloudFlareService.Object);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        var worker = new DynamicDnsWorker(logger, scopeFactory);
 
         var cts = new CancellationTokenSource();
         cts.CancelAfter(200); // Short run


### PR DESCRIPTION
Added validation in CloudFlareHttpClient to skip records missing ZoneId, DnsRecordId, or Name, logging a warning when encountered. Updated and expanded unit tests for CloudFlareHttpClient to verify API calls for both proxied and non-proxied records. Refactored DynamicDnsWorkerTests to use dependency injection for improved testability.