### PR TITLE
Remove PROJECT env var from restore and build steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,10 @@ jobs:
             8.0.x
 
       - name: Restore dependencies
-        run: dotnet restore ${{ env.PROJECT }}
+        run: dotnet restore
 
       - name: Build
-        run: dotnet build ${{ env.PROJECT }} --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+        run: dotnet build --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
       - name: Test
         run: dotnet test --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal


### PR DESCRIPTION
Updated the GitHub Actions workflow to run 'dotnet restore' and 'dotnet build' without specifying the PROJECT environment variable, simplifying the commands.